### PR TITLE
Add use case diagram feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can also replace `hub` with `diagram` in any Github URL to access its diagra
 - ⚡ **Fast Generation**: Powered by OpenAI o4-mini for quick and accurate diagrams
 - 🔄 **Customization**: Modify and regenerate diagrams with custom instructions
 - 🌐 **API Access**: Public API available for integration (WIP)
+- 📝 **Use case to diagram**: Describe an enterprise workflow and get a diagram
+  generated with Mermaid and Kroki
 
 ## ⚙️ Tech Stack
 
@@ -100,6 +102,16 @@ pnpm dev
 ```
 
 You can now access the website at `localhost:3000` and edit the rate limits defined in `backend/app/routers/generate.py` in the generate function decorator.
+
+### Generate diagrams from a use case description
+
+You can also create diagrams directly from text:
+
+```bash
+python backend/app/scripts/generate_usecase_diagram.py \
+  --description "A generative AI workflow for enterprise support" \
+  --output ai_use_case.svg
+```
 
 ## Contributing
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from app.routers import generate, modify
+from app.routers import generate, modify, usecase
 from app.core.limiter import limiter
 from typing import cast
 from starlette.exceptions import ExceptionMiddleware
@@ -34,6 +34,7 @@ app.add_exception_handler(
 
 app.include_router(generate.router)
 app.include_router(modify.router)
+app.include_router(usecase.router)
 
 
 @app.get("/")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+from . import generate, modify, usecase

--- a/backend/app/routers/usecase.py
+++ b/backend/app/routers/usecase.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import base64
+import requests
+
+from app.services.o1_mini_openai_service import OpenAIO1Service
+from app.services.o3_mini_openai_service import OpenAIo3Service
+from app.services.o4_mini_openai_service import OpenAIo4Service
+
+PROMPT = (
+    "You are a helpful assistant that generates Mermaid.js diagrams. "
+    "Given a description of an enterprise generative AI use case, decide the "
+    "best diagram type (use case, sequence, gantt, etc.) and output ONLY the "
+    "Mermaid syntax. Ensure the syntax uses the correct properties for the "
+    "chosen diagram."
+)
+
+router = APIRouter(prefix="/usecase", tags=["Use Case Diagram"])
+
+class UseCaseRequest(BaseModel):
+    description: str
+    model: str = "o1"
+    api_key: str | None = None
+
+MODEL_MAP = {
+    "o1": OpenAIO1Service,
+    "o3": OpenAIo3Service,
+    "o4": OpenAIo4Service,
+}
+
+def get_service(model: str):
+    service_cls = MODEL_MAP.get(model, OpenAIO1Service)
+    return service_cls()
+
+def call_model(service, description: str, api_key: str | None):
+    if isinstance(service, OpenAIO1Service):
+        return service.call_o1_api(PROMPT, {"explanation": description}, api_key)
+    if isinstance(service, OpenAIo3Service):
+        return service.call_o3_api(PROMPT, {"explanation": description}, api_key)
+    return service.call_o4_api(PROMPT, {"explanation": description}, api_key)
+
+def render_svg(mermaid_code: str) -> bytes:
+    resp = requests.post("https://kroki.io/mermaid/svg", data=mermaid_code.encode("utf-8"))
+    if resp.status_code != 200:
+        raise HTTPException(status_code=500, detail="Kroki rendering failed")
+    return resp.content
+
+@router.post("")
+async def generate_diagram(body: UseCaseRequest):
+    service = get_service(body.model)
+    mermaid = call_model(service, body.description, body.api_key)
+    svg_bytes = render_svg(mermaid)
+    svg_b64 = base64.b64encode(svg_bytes).decode("utf-8")
+    return {"svg": svg_b64, "mermaid": mermaid}

--- a/backend/app/scripts/generate_usecase_diagram.py
+++ b/backend/app/scripts/generate_usecase_diagram.py
@@ -1,0 +1,59 @@
+import argparse
+import base64
+import sys
+import requests
+
+from app.services.o1_mini_openai_service import OpenAIO1Service
+from app.services.o3_mini_openai_service import OpenAIo3Service
+from app.services.o4_mini_openai_service import OpenAIo4Service
+
+PROMPT = (
+    "You are a helpful assistant that generates Mermaid.js diagrams. "
+    "Given a description of an enterprise generative AI use case, decide the "
+    "best diagram type (use case, sequence, gantt, etc.) and output ONLY the "
+    "Mermaid syntax. Ensure the syntax uses the correct properties for the "
+    "chosen diagram."
+)
+
+MODEL_MAP = {
+    "o1": OpenAIO1Service,
+    "o3": OpenAIo3Service,
+    "o4": OpenAIo4Service,
+}
+
+def get_service(model: str):
+    service_cls = MODEL_MAP.get(model, OpenAIO1Service)
+    return service_cls()
+
+def call_model(service, description: str, api_key: str | None):
+    return service.call_o1_api(PROMPT, {"explanation": description}, api_key) if isinstance(service, OpenAIO1Service) else (
+        service.call_o3_api(PROMPT, {"explanation": description}, api_key) if isinstance(service, OpenAIo3Service) else service.call_o4_api(PROMPT, {"explanation": description}, api_key)
+    )
+
+def render_svg(mermaid_code: str) -> bytes:
+    resp = requests.post("https://kroki.io/mermaid/svg", data=mermaid_code.encode("utf-8"))
+    resp.raise_for_status()
+    return resp.content
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Generate a Mermaid diagram from a use case description")
+    parser.add_argument("--description", help="Description of the use case")
+    parser.add_argument("--output", required=True, help="Path to output SVG")
+    parser.add_argument("--model", choices=["o1", "o3", "o4"], default="o1")
+    parser.add_argument("--api-key", dest="api_key")
+    args = parser.parse_args(argv)
+
+    description = args.description
+    if not description:
+        description = sys.stdin.read()
+
+    service = get_service(args.model)
+    mermaid = call_model(service, description, args.api_key)
+    svg_bytes = render_svg(mermaid)
+    with open(args.output, "wb") as f:
+        f.write(svg_bytes)
+    print("Diagram saved to", args.output)
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_usecase.py
+++ b/backend/tests/test_usecase.py
@@ -1,0 +1,20 @@
+import base64
+import unittest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from app.main import app
+
+class UseCaseEndpointTest(unittest.TestCase):
+    def test_usecase_endpoint(self):
+        with patch('app.routers.usecase.call_model', return_value='graph TD;A-->B'):
+            with patch('app.routers.usecase.render_svg', return_value=b'<svg></svg>'):
+                client = TestClient(app)
+                resp = client.post('/usecase', json={'description': 'test'})
+                self.assertEqual(resp.status_code, 200)
+                data = resp.json()
+                self.assertEqual(data['mermaid'], 'graph TD;A-->B')
+                self.assertEqual(base64.b64decode(data['svg']), b'<svg></svg>')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/app/usecase/page.tsx
+++ b/src/app/usecase/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import MermaidChart from "~/components/mermaid-diagram";
+import LoadingAnimation from "~/components/loading-animation";
+
+export default function UseCasePage() {
+  const [description, setDescription] = useState("");
+  const [model, setModel] = useState("o1");
+  const [diagram, setDiagram] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const baseUrl =
+        process.env.NEXT_PUBLIC_API_DEV_URL ?? "https://api.gitdiagram.com";
+      const res = await fetch(`${baseUrl}/usecase`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          description,
+          model,
+          api_key: localStorage.getItem("openai_key") ?? undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) {
+        setError(data.error ?? "Failed to generate diagram");
+      } else {
+        setDiagram(data.mermaid);
+      }
+    } catch (err) {
+      setError("Failed to generate diagram");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center p-4">
+      <h1 className="mt-8 text-center text-2xl font-semibold">
+        Use case to diagram.
+      </h1>
+      <form
+        onSubmit={handleSubmit}
+        className="mt-4 flex w-full max-w-xl flex-col gap-4"
+      >
+        <textarea
+          className="min-h-[120px] w-full rounded border p-2"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <select
+          className="w-32 rounded border p-2"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        >
+          <option value="o1">o1</option>
+          <option value="o3">o3</option>
+          <option value="o4">o4</option>
+        </select>
+        <button
+          type="submit"
+          className="rounded bg-purple-600 px-4 py-2 font-medium text-white"
+          disabled={loading}
+        >
+          Generate
+        </button>
+      </form>
+      {loading && (
+        <div className="mt-8">
+          <LoadingAnimation />
+        </div>
+      )}
+      {error && <p className="mt-4 text-center text-red-600">{error}</p>}
+      {diagram && !loading && (
+        <div className="mt-8 w-full">
+          <MermaidChart chart={diagram} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -69,6 +69,12 @@ export function Header() {
             <span className="hidden sm:inline">Private Repos</span>
           </span>
           <Link
+            href="/usecase"
+            className="text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600"
+          >
+            Use case to diagram
+          </Link>
+          <Link
             href="https://github.com/ahmedkhaleel2004/gitdiagram"
             className="flex items-center gap-1 text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 sm:gap-2"
           >


### PR DESCRIPTION
## Summary
- add CLI script to produce diagrams from text descriptions
- provide `/usecase` API route for generating diagrams
- register router in backend app
- include unit test for the new endpoint
- implement new page `/usecase` and link in header
- document feature and CLI usage in README

## Testing
- `pnpm format:write`
